### PR TITLE
added declarativeness to main endpoints

### DIFF
--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,20 +1,26 @@
 from fastapi import APIRouter, Depends
 from ..database import get_redis_text
+from ..exceptions import AppError
 from ..log_root import log_ctx
+from ..schemas import ErrorResponse, HealthResponse
 
 router = APIRouter(tags=["health"])
 
 
-@router.get("/ping-redis")
+@router.get(
+    "/ping-redis",
+    response_model=HealthResponse,
+    responses={503: {"model": ErrorResponse}},
+)
 async def ping_redis(redis_text=Depends(get_redis_text)):
     log = log_ctx(endpoint="ping-redis")
     
     log.info("request_received")
     if not redis_text:
-        log.error("Redis connection failed")
-        return {"error": "Redis not connected"}
+        log.error("redis_not_connected")
+        raise AppError("Redis not connected", status_code=503)
     val = await redis_text.get("some_key")
     if val is None:
-        log.error("Failed to retrieve value from Redis")
-        return {"error": "Failed to retrieve value from Redis"}
+        log.error("redis_probe_failed")
+        raise AppError("Failed to retrieve value from Redis", status_code=503)
     return {"redis_status": "online", "value": val}

--- a/app/routers/images.py
+++ b/app/routers/images.py
@@ -29,7 +29,13 @@ from ..exceptions import (
 )
 from ..models import ImageStore, User
 from ..query_redis_cli import fetch_file_by_user_id
-from ..schemas import WatermarkPhotoRequest
+from ..schemas import (
+    ErrorResponse,
+    StatusMessageResponse,
+    UploadResponse,
+    WatermarkPhotoRequest,
+    WatermarkResponse,
+)
 from ..log_root import log_ctx
 import logging
 
@@ -117,7 +123,16 @@ async def fetch_active_image(redis_text, redis_binary, user_id: int) -> tuple[st
     return file_id, image_bytes
 
 
-@router.post("/upload")
+@router.post(
+    "/upload",
+    response_model=UploadResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        401: {"model": ErrorResponse},
+        413: {"model": ErrorResponse},
+        429: {"model": ErrorResponse},
+    },
+)
 async def upload_image(
     file: UploadFile = File(...),
     redis_text=Depends(get_redis_text),
@@ -200,7 +215,11 @@ async def upload_image(
         "size": image_size,
     }
     
-@router.post("/filter")
+@router.post(
+    "/filter",
+    response_model=StatusMessageResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def filter_image(
     filter_type: str = "normal",
     current_user: User = Depends(get_current_user),
@@ -224,7 +243,11 @@ async def filter_image(
     return {"status": "success", "message": "Image filtered"}
 
 
-@router.post("/resize")
+@router.post(
+    "/resize",
+    response_model=StatusMessageResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def resize_endpoint(
     width: int = 256,
     height: int = 256,
@@ -259,7 +282,11 @@ async def resize_endpoint(
 #         detail="Image clarity feature is not yet implemented",
 #     )
 
-@router.post("/flip")
+@router.post(
+    "/flip",
+    response_model=StatusMessageResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def flip_image(
     direction: str = "horizontal",
     current_user: User = Depends(get_current_user),
@@ -277,7 +304,11 @@ async def flip_image(
     return {"status": "success", "message": "Image flipped"}
 
 
-@router.post("/rotate")
+@router.post(
+    "/rotate",
+    response_model=StatusMessageResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def rotate_image(
     angle: int,
     current_user: User = Depends(get_current_user),
@@ -298,7 +329,11 @@ async def rotate_image(
     return {"status": "success", "message": f"Rotated by {angle}"}
 
 
-@router.post("/watermark")
+@router.post(
+    "/watermark",
+    response_model=WatermarkResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def watermark_image(
     watermark_params: WatermarkPhotoRequest = Depends(WatermarkPhotoRequest.as_form),
     logo_file: UploadFile = File(...),
@@ -365,7 +400,16 @@ async def watermark_image(
     finally:
         Path(logo_path).unlink(missing_ok=True)
 
-@router.post("/remove_bg")
+@router.post(
+    "/remove_bg",
+    response_model=StatusMessageResponse,
+    responses={
+        400: {"model": ErrorResponse},
+        401: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
+)
 async def remove_bg(
     current_user: User = Depends(get_current_user),
     redis_text=Depends(get_redis_text),
@@ -434,7 +478,11 @@ async def export_current_image(
     )
 
 
-@router.delete("/{image_id}")
+@router.delete(
+    "/{image_id}",
+    response_model=StatusMessageResponse,
+    responses={400: {"model": ErrorResponse}, 401: {"model": ErrorResponse}, 404: {"model": ErrorResponse}},
+)
 async def delete_image(
     image_id: str,
     current_user: User = Depends(get_current_user),

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -3,11 +3,16 @@ from fastapi import APIRouter, Depends
 from ..auth import get_current_user
 from ..log_root import log_ctx
 from ..models import User
+from ..schemas import ErrorResponse, UserResponse
 
 router = APIRouter(tags=["users"])
 
 
-@router.get("/profile")
+@router.get(
+    "/profile",
+    response_model=UserResponse,
+    responses={401: {"model": ErrorResponse}},
+)
 def get_profile(current_user: User = Depends(get_current_user)):
     log = log_ctx(endpoint="profile", user_id=current_user.id)
     log.info("request_received")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import Form
 from pydantic import BaseModel, Field, ConfigDict
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Literal, Tuple
 
 class ImageID(BaseModel):
     id: int
@@ -26,6 +26,32 @@ class UserResponse(BaseModel):
 class Token(BaseModel):
     access_token: str
     token_type: str
+
+class ErrorResponse(BaseModel):
+    detail: str
+
+class StatusMessageResponse(BaseModel):
+    status: str
+    message: str
+
+class UploadResponse(BaseModel):
+    status: Literal["uploaded", "already_uploaded"]
+    file_id: str
+    format: str | None = None
+    size: Tuple[int, int] | None = None
+
+class HealthResponse(BaseModel):
+    redis_status: Literal["online"]
+    value: str
+
+class WatermarkResponse(StatusMessageResponse):
+    opacity: float
+    rotation: int
+    scale: float
+    density: float
+    randomize: bool
+    jitter: float
+    seed: Optional[int] = None
 
 class TokenData(BaseModel):
     username: Optional[str] = None
@@ -99,4 +125,3 @@ class TransformPhotoRequest(ImageID):
     compress: Optional[CompressPhotoRequest]
     change_format: Optional[ChangePhotoRequest]
     filter: Optional[FilterPhotoRequest]
-


### PR DESCRIPTION
In the old code, functions simply returned regular dictionaries (return {"status": "success", ...}).  In the new code, I added declarativeness. Now, the decorators have response_model and responses parameters. Swagger now has a detailed description of which fields will be returned in case of success and which ones in case of an error.